### PR TITLE
Fixing of errors found in analytic classification algorithm

### DIFF
--- a/lib/AnalyticClassification/MorphologicalClassification.cc
+++ b/lib/AnalyticClassification/MorphologicalClassification.cc
@@ -1,4 +1,6 @@
 #include <math.h>
+#include <iostream>
+
 using namespace std;
 
 #include "Particle.h"
@@ -19,10 +21,13 @@ int GetMorphologicalClass(particle const& p)
 			{
 				if( (inner<HeavyTracks::MinimumInnerCount) | (InnerToOuter<HeavyTracks::MinimumInnerToOuterRatio) | (maxdist < (HeavyTracks::MinimumRadiusDeviation*diameter)) )
 				{
-					double lin = LLMLinearity(p);
-					if( (lin<StraightTracks::MinimumLinearity) | (lin*p.GetSize()<StraightTracks::MinimumInLinePixels) )//Originally was 20 in line pixels
+					double lin = Linearity(p);
+					if( (lin<StraightTracks::MinimumLinearity) | (lin*p.GetSize()<StraightTracks::MinimumInLinePixels) )
 					{
-						return 5; //Curly Tracks
+						if(p.GetSize()>CurlyTracks::MaximumSize)
+							return 3; //Accounting for misclassification of volcano affect
+						else
+							return 5; //Curly Tracks
 					}
 					else
 						return 4; //Straight Tracks

--- a/lib/AnalyticClassification/MorphologicalClassification.h
+++ b/lib/AnalyticClassification/MorphologicalClassification.h
@@ -27,9 +27,10 @@ namespace HeavyTracks
 namespace StraightTracks
 {
 	const double MinimumLinearity = 0.9;
-	const int MinimumInLinePixels = 5;
+	const int MinimumInLinePixels = 4;//Originally was 20 in line pixels
 }
 namespace CurlyTracks
 {
-
+ 	const int MaximumSize=250;
+ 	const int MaximumNodes=10;
 }

--- a/lib/ClusterFunctions/ClusterFeatures.cc
+++ b/lib/ClusterFunctions/ClusterFeatures.cc
@@ -57,36 +57,19 @@ vector<double> LineFit(particle const& p)
 
 double PixelsInLine(particle const&p, int XFuncOrYYFunc, PixelHit const& p1, PixelHit const& p2)
 {
-	double m;
-	double n=0;	
-	if(XFuncOrYYFunc==0)
+	double n=0;
+	double m_dx = (p2.x - p1.x);
+	double m_dy = (p2.y - p1.y);
+	for (auto i = p.begin(); i != p.end(); i++ ) 
 	{
-		m = (p2.y - p1.y)/(p2.x - p1.x);
-		double A = -m;
-		double B = 1;
-		double C = m*p1.x-p1.y;
-		for (auto i = p.begin(); i != p.end(); i++ ) 
-		{
-			double d = abs((i->x*A + i->y*B + C)/sqrt(A*A + B*B));
-			if(d<1.0)//0.7071?
-				n+=1;
-		}
-	}
-	else
-	{
-		m = (p2.x - p1.x)/(p2.y - p1.y);
-		double A = -m;
-		double B = 1;
-		double C = m*p1.y-p1.x;
-		for (auto i = p.begin(); i != p.end(); i++ ) 
-		{
-			double d = abs((i->y*A + i->x*B + C)/sqrt(A*A + B*B));
-			if(d<1.0) 
-				n+=1;
-		}
+		//double dist = abs( m_dx * ( p1.y - i->y) - m_dy * ( p1.x - i->x) );
+		double dist = abs( m_dx * (i->y - p1.y) - m_dy * (i->x - p1.x));
+		if(dist<=1.0)//0.7071?
+			n+=1;
 	}
 	return n;
 }
+
 
 double Linearity(particle const& p)
 {
@@ -380,7 +363,7 @@ double NumberOfInnerPixels(particle const& p)
 			if(( (i->x-1) == j->x) & ((i->y) == j->y))
 				n++;
 		}
-		if(n==0)
+		if(n==4)
 			InnerPixels++;
 	}
 	return InnerPixels;
@@ -412,6 +395,3 @@ double MaximumDistance(particle const& p)
 	
 	return m;
 }
-
-
-

--- a/lib/FileOperators/FileWriters/ParticleFileWriters.cc
+++ b/lib/FileOperators/FileWriters/ParticleFileWriters.cc
@@ -16,7 +16,7 @@ PxFileWriter::PxFileWriter(const string& opFileName, double DetectorThickness)
 	fprintf(opInitFile_, "PxFile=%s\n", (RemoveDirectoryPath(opFileName) + "_px.txt").c_str());
 	fprintf(opInitFile_, "ClFile=%s\n", (RemoveDirectoryPath(opFileName) + "_cl.txt").c_str());
 	fprintf(opInitFile_, "Version=0\nFormat=txt\n");
-	
+	fclose(opInitFile_);
 	opClFile_ = fopen((opFileName+"_cl.txt").c_str(),"w");
 	opPxFile_ = fopen((opFileName+"_px.txt").c_str(),"w");
 	PxLineNo_=0; 
@@ -52,7 +52,6 @@ void PxFileWriter::AddInitInfo(const string&  ipInfo)
 
 void PxFileWriter::Close()
 {
-	fclose(opInitFile_);
 	fclose(opClFile_);
 	fclose(opPxFile_);
 }


### PR DESCRIPTION
- Error was found in nearest neighbour calculation was fixed 
- An extra if statement was applyed in the morphological classification to account for heavily volcanoed particles 
- Unrelated: All particle file writing algorithms were updated to use the most effect phi calculation algorithm "weighted phi" 